### PR TITLE
Fix terrible type converting (#343)

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -159,17 +159,18 @@ class Curl:
         input_option = {
             # this should be int in curl, but cffi requires pointer for void*
             # it will be convert back in the glue c code.
-            0: "int*",
+            0: "long*",
             10000: "char*",
             20000: "void*",
-            30000: "int*",  # offset type
+            30000: "int64_t*",  # offset type
+            40000: "void*",     # blob type
         }
         # print("option", option, "value", value)
 
         # Convert value
-        value_type = input_option.get(int(option / 10000) * 10000)
-        if value_type == "int*":
-            c_value = ffi.new("int*", value)
+        value_type = input_option.get((option // 10000) * 10000)
+        if value_type == "long*" or value_type == "int64_t*":
+            c_value = ffi.new(value_type, value)
         elif option == CurlOpt.WRITEDATA:
             c_value = ffi.new_handle(value)
             self._write_handle = c_value

--- a/ffi/shim.c
+++ b/ffi/shim.c
@@ -1,16 +1,18 @@
-#include "shim.h"
 
-#define INTEGER_OPTION_MAX 10000
+#include "shim.h"
 
 int _curl_easy_setopt(void* curl, int option, void* parameter) {
     // printf("****** hijack test begins: \n");
     // int val = curl_easy_setopt(instance->curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
     // printf("****** hijack test ends. opt: %d, val: %d, result is: %d\n", CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0, val);
-    CURLoption opt_value = (CURLoption) option;
+    // CURLoption opt_value = (CURLoption) option;
     // printf("option: %d, setopt parameter: %d\n", option, *(int*)parameter);
     // for integer options, we need to convert param from pointers to integers
-    if (option < INTEGER_OPTION_MAX) {
-        return (int)curl_easy_setopt(curl, (CURLoption)option, *(int*)parameter);
+    if (option < CURLOPTTYPE_OBJECTPOINT) {
+        return (int)curl_easy_setopt(curl, (CURLoption)option, *(long*)parameter);
+    }
+    if (CURLOPTTYPE_OFF_T <= option && option < CURLOPTTYPE_BLOB) {
+        return (int)curl_easy_setopt(curl, (CURLoption)option, *(curl_off_t*)parameter);
     }
     return (int)curl_easy_setopt(curl, (CURLoption)option, parameter);
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses incorrect type conversions in the _curl_easy_setopt function and the setopt method in curl_cffi/curl.py. It ensures proper handling of long* and int64_t* types for integer and offset options, respectively.

- **Bug Fixes**:
    - Corrected type conversion for integer options in the _curl_easy_setopt function to use long* instead of int*.
    - Fixed type conversion for offset options in the _curl_easy_setopt function to use curl_off_t* instead of int*.
- **Enhancements**:
    - Updated the setopt method in curl_cffi/curl.py to handle long* and int64_t* types correctly.

<!-- Generated by sourcery-ai[bot]: end summary -->