### PR TITLE
Add raise_for_status parameter to Session and AsyncSession (#651)

### DIFF
--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -457,3 +457,25 @@ async def test_stream_atext(server):
             text = await r.atext()
             chunks = text.split("\n")
             assert len(chunks) == 20
+
+
+async def test_async_session_auto_raise_for_status_enabled(server):
+    """Test that AsyncSession automatically raises HTTPError for error status codes
+    when raise_for_status=True"""
+    from curl_cffi.requests.exceptions import HTTPError
+    
+    async with AsyncSession(raise_for_status=True) as s:
+        try:
+            await s.get(str(server.url.copy_with(path="/status/404")))
+            raise AssertionError("Should have raised HTTPError for 404")
+        except HTTPError as e:
+            assert e.response.status_code == 404  # type: ignore
+
+
+async def test_async_session_auto_raise_for_status_disabled(server):
+    """Test that AsyncSession does NOT raise HTTPError when raise_for_status=False
+    (default)"""
+    async with AsyncSession(raise_for_status=False) as s:
+        r = await s.get(str(server.url.copy_with(path="/status/404")))
+        assert r.status_code == 404
+        # Should not raise an exception

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -982,3 +982,23 @@ def test_response_ip_and_port(server):
 def test_http_version(server):
     r = requests.get(str(server.url), http_version="v1")
     assert r.status_code == 200
+
+
+def test_session_auto_raise_for_status_enabled(server):
+    """Test that Session automatically raises HTTPError for error status codes
+    when raise_for_status=True"""
+    s = requests.Session(raise_for_status=True)
+    try:
+        s.get(str(server.url.copy_with(path="/status/404")))
+        raise AssertionError("Should have raised HTTPError for 404")
+    except HTTPError as e:
+        assert e.response.status_code == 404  # type: ignore
+
+
+def test_session_auto_raise_for_status_disabled(server):
+    """Test that Session does NOT raise HTTPError when raise_for_status=False
+    (default)"""
+    s = requests.Session(raise_for_status=False)
+    r = s.get(str(server.url.copy_with(path="/status/404")))
+    assert r.status_code == 404
+    # Should not raise an exception


### PR DESCRIPTION
* Add raise_for_status parameter to Session and AsyncSession

- Add raise_for_status parameter (default: False) to both Session and AsyncSession
- Automatically raises HTTPError for 4xx/5xx status codes when enabled
- Similar to aiohttp's raise_for_status parameter
- Add 4 unit tests (2 sync, 2 async) to verify functionality
- Maintains 100% backward compatibility with default False value

* Fix linting: break long docstring lines to <= 88 chars

* Fix linting: line length and assert statements

## Summary by Sourcery

Add a raise_for_status option to Session and AsyncSession to automatically raise HTTPError on error responses by default off to maintain backward compatibility

New Features:
- Introduce raise_for_status parameter to Session and AsyncSession
- Enable automatic HTTPError raising for 4xx/5xx responses when raise_for_status is set

Enhancements:
- Fix linting by wrapping long docstring lines and adjusting line length/assert statements

Tests:
- Add unit tests for both sync and async sessions to verify raise_for_status enabled and disabled behavior